### PR TITLE
gst-client now compiles and runs

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 
-bin_PROGRAMS = gstd #gst-client
+bin_PROGRAMS = gstd gst-client
 
 gstd_SOURCES = gstd-interfaces.vala gstd-main.vala gstd-factory.vala gstd-pipeline.vala gstd-signals.vala
 gstd_VALAFLAGS = --thread --vapidir=@VAPIDIR@ --vapidir=. --pkg gstd-config \
@@ -9,15 +9,15 @@ gstd_VALAFLAGS = --thread --vapidir=@VAPIDIR@ --vapidir=. --pkg gstd-config \
 gstd_CFLAGS = @GSTREAMER_CFLAGS@ @GSTREAMER_INTERFACES_CFLAGS@ @GIO_CFLAGS@
 gstd_LDADD = @GSTREAMER_LIBS@ @GSTREAMER_INTERFACES_LIBS@ @GIO_LIBS@
 
-#gst_client_SOURCES = gstd-interfaces.vala gst-client.vala
-#gst_client_VALAFLAGS = --vapidir=@VAPIDIR@ --vapidir=. --pkg gstd-config \
-#    --pkg gio-2.0 --pkg gstreamer-0.10 --pkg gstreamer-interfaces-0.10 --pkg posix \
-#    @READLINE_SUPPORT@
-#gst_client_CFLAGS = @GSTREAMER_CFLAGS@
-#gst_client_LDADD = @GSTREAMER_LIBS@ @GSTREAMER_INTERFACES_LIBS@ @READLINE_LIBS@
+gst_client_SOURCES = gstd-interfaces.vala gst-client.vala
+gst_client_VALAFLAGS = --vapidir=@VAPIDIR@ --vapidir=. --pkg gstd-config \
+    --pkg gio-2.0 --pkg gstreamer-0.10 --pkg gstreamer-interfaces-0.10 --pkg posix \
+    @READLINE_SUPPORT@
+gst_client_CFLAGS = @GSTREAMER_CFLAGS@
+gst_client_LDADD = @GSTREAMER_LIBS@ @GSTREAMER_INTERFACES_LIBS@ @GIO_LIBS@ @READLINE_LIBS@
 
-#install-data-hook:
-#	cd $(bindir) ; rm -f gst-client-interpreter ; $(LN_S) gst-client gst-client-interpreter
+install-data-hook:
+	cd $(bindir) ; rm -f gst-client-interpreter ; $(LN_S) gst-client gst-client-interpreter
 
 interfaces_xml := com.ridgerun.gstreamer.gstd.FactoryInterface.xml \
  com.ridgerun.gstreamer.gstd.PipelineInterface.xml

--- a/src/gst-client.vala
+++ b/src/gst-client.vala
@@ -79,78 +79,86 @@ public class GstdCli : GLib.Object
 	/* Command descriptions for the help
 	   Each description is: name of the command, syntax, description
 	 */
-	private const string[, ] cmds = {
-		{ "create", "create <\"gst-launch like pipeline description in quotes\">",
-		  "Creates a new pipeline and returns the dbus-path to access it"},
-		{ "destroy", "destroy", "Destroys the pipeline specified by_path(-p) or the"
-		  + " active pipeline"},
-		{ "destroy-all", "destroy-all", "Destroys all pipelines on the factory."},
-		{ "play", "play", "Sets the pipeline specified by_path(-p) or the active "
-		  + "pipeline to play state"},
-		{ "ready", "ready", "Sets the pipeline specified by_path(-p) or the active "
-		  + "pipeline to ready state"},
-		{ "pause", "pause", "Sets the pipeline specified by_path(-p) or the active "
-		  + "pipeline to pause state"},
-		{ "null", "null", "Sets the pipeline specified by_path(-p) or active "
-		  + "pipeline to null state"},
-		{ "aplay", "play-async", "Sets the pipeline to play state, it does not "
-		  + "wait the change to be done"},
-		{ "aready", "ready-async", "Sets the pipeline to ready state, it does not "
-		  + "wait the change to be done"},
-		{ "apause", "pause-async", "Sets the pipeline to pause state, it does not "
-		  + "wait the change to be done"},
-		{ "anull", "null-async", "Sets the pipeline to null state, it does not wait "
-		  + "the change to be done"},
-		{ "set", "set <element_name> <property_name> <data-type> <value>",
+	private const string[] cmds = {
+		"create|"+"create <\"gst-launch like pipeline description in quotes\">|"
+		  + "Creates a new pipeline and returns the dbus-path to access it",
+		"destroy|"+"destroy|"+"Destroys the pipeline specified by_path(-p) or the"
+		  + " active pipeline",
+		"destroy-all|"+"destroy-all|"+"Destroys all pipelines on the factory.",
+		"play|"+"play|"+"Sets the pipeline specified by_path(-p) or the active "
+		  + "pipeline to play state",
+		"ready|"+"ready|"+"Sets the pipeline specified by_path(-p) or the active "
+		  + "pipeline to ready state",
+		"pause|"+"pause|"+"Sets the pipeline specified by_path(-p) or the active "
+		  + "pipeline to pause state",
+		"null|"+"null|"+"Sets the pipeline specified by_path(-p) or active "
+		  + "pipeline to null state",
+		"aplay|"+"play-async|"+"Sets the pipeline to play state, it does not "
+		  + "wait the change to be done",
+		"aready|"+"ready-async|"+"Sets the pipeline to ready state, it does not "
+		  + "wait the change to be done",
+		"apause|"+"pause-async|"+"Sets the pipeline to pause state, it does not "
+		  + "wait the change to be done",
+		"anull|"+"null-async|"+"Sets the pipeline to null state, it does not wait "
+		  + "the change to be done",
+		"set|"+"set <element_name> <property_name> <data-type> <value>|"+
 		  "Sets an element's property value of the pipeline\n" +
-		  "\t\tSupported <data-type>s include: boolean, integer, int64, and " +
-		  "string"},
-		{ "get", "get <element_name> <property_name> <data_type>",
-		  "Gets an element's property value of the pipeline"},
-		{ "get-duration", "get-duration", "Gets the pipeline duration time"},
-		{ "get-position", "get-position", "Gets the pipeline position"},
-		{ "sh", "sh \"<shell command with optional parameters>\"",
-		  "Execute a shell command using interactive console"},
-		{ "get-state", "get-state", "Get the state of a specific pipeline(-p flag)"
-		  + " or the active pipeline"},
-		{ "get-elem-state", "get-elem-state", "Get the state of a specific element of"
-		  + "the active pipeline"},
-		{ "list-pipes", "list-pipes", "Returns a list of all the dbus-path of"
-		  + "the existing pipelines"},
-		{ "ping", "ping", "Shows if gstd is alive"},
-		{ "ping-pipe", "ping-pipe", "Test if the active pipeline is alive"},
-		{ "active", "active <path>", "Sets the active pipeline,if no <path> is "
-		  + "passed:it returns the actual active pipeline"},
-		{ "seek", "seek <position[ms]>", "Moves current playing position to a new"
-		  + " one"},
-		{ "skip", "skip <period[ms]>", "Skips a period, if period is positive: it"
-		  + " moves forward, if negative: it moves backward"},
-		{ "speed", "speed <rate>", "Changes playback rate:\n" +
+		  "\t\tSupported <data-type>s include: boolean, integer, int64, double and " +
+		  "string",
+		"get|"+"get <element_name> <property_name> <data_type>|"+
+		  "Gets an element's property value of the pipeline",
+		"get-duration|"+"get-duration|"+"Gets the pipeline duration time",
+		"get-position|"+"get-position|"+"Gets the pipeline position",
+		"sh|"+"sh \"<shell command with optional parameters>\"|"+
+		  "Execute a shell command using interactive console",
+		"get-state|"+"get-state|"+"Get the state of a specific pipeline(-p flag)"
+		  + " or the active pipeline",
+		"get-elem-state|"+"get-elem-state|"+"Get the state of a specific element of"
+		  + "the active pipeline",
+		"list-pipes|"+"list-pipes|"+"Returns a list of all the dbus-path of"
+		  + "the existing pipelines",
+		"ping|"+"ping|"+"Shows if gstd is alive",
+		"ping-pipe|"+"ping-pipe|"+"Test if the active pipeline is alive",
+		"active|"+"active <path>|"+"Sets the active pipeline,if no <path> is "
+		  + "passed:it returns the actual active pipeline",
+		"seek|"+"seek <position[ms]>|"+"Moves current playing position to a new"
+		  + " one",
+		"skip|"+"skip <period[ms]>|"+"Skips a period, if period is positive: it"
+		  + " moves forward, if negative: it moves backward",
+		"speed|"+"speed <rate>|"+"Changes playback rate:\n" +
 		  "\t\t* rate>1.0: fast-forward playback,\n" +
 		  "\t\t* rate<1.0: slow-forward playback,\n" +
 		  "\t\t* rate=1.0: normal speed.\n" +
-		  "\t\tNegative rate causes reverse playback."},
-		{ "step", "step [number of frames]", "Step the number of frames, if no number is provided, 1 is assumed"},
-		{ "send-eos", "send-eos", "Send an EOS event on the pipeline"},
-		{ "send-custom-event", "send-custom-event <custom type> <name of event>",
+		  "\t\tNegative rate causes reverse playback.",
+		"step|"+"step [number of frames]|"+"Step the number of frames, if no number is provided, 1 is assumed",
+		"send-eos|"+"send-eos|"+"Send an EOS event on the pipeline",
+		"send-custom-event|"+"send-custom-event <custom type> <name of event>|"+
 		  "Send a custom event on the pipeline. The event type can be:\n" +
 		  "\t\t* UPSTREAM\n" +
 		  "\t\t* DOWNSTREAM\n" +
 		  "\t\t* DOWNSTREAM_OOB\n" +
 		  "\t\t* BOTH\n" +
-		  "\t\t* BOTH_OOB\n"},
-		{ "element-set-state", "element-set-state <element_name> <state>",
+		  "\t\t* BOTH_OOB\n",
+		"element-set-state|"+"element-set-state <element_name> <state>|"+
 		  "Sets the element state" +
-		  "\t\tSupported <state>s include: null, ready, paused, playing"},
-		{ "element-async-set-state", "element-async-set-state <element_name> <state>",
-		  "Sets the element state, it does not wait the change to be done"},
-		{ "exit", "exit", "Exit/quit active console"},
-		{ "quit", "quit", "Exit/quit active console"},
+		  "\t\tSupported <state>s include: null, ready, paused, playing",
+		"element-async-set-state|"+"element-async-set-state <element_name> <state>|"+
+		  "Sets the element state, it does not wait the change to be done",
+		"exit|"+"exit|"+"Exit/quit active console",
+		"quit|"+"quit|"+"Exit/quit active console",
 		# if HAVE_READLINE
-		{ "strict", "strict", "Enable/disable strict execution mode."},
+		"strict|"+"strict|"+"Enable/disable strict execution mode.",
 		# endif
-		{ "version", "version", "Show gst-client version."}
+		"version|"+"version|"+"Show gst-client version."
 	};
+
+	private string? Cmds(int idx0, int idx1)
+	{
+		if (idx0 >= cmds.length)
+			return null;
+		string[] cmd = cmds[idx0].split("|");
+		return cmd[idx1];
+	}
 
 	/*
 	 * Constructor
@@ -258,7 +266,7 @@ public class GstdCli : GLib.Object
 				}
 			}
 			else
-				pipeline.pipeline_async_set_state (state);
+				pipeline.pipeline_set_state_async (state);
 
 			stdout.printf ("Ok.\n");
 			return true;
@@ -384,6 +392,19 @@ public class GstdCli : GLib.Object
 					               property, element, int64_v);
 					break;
 
+				case "double":
+					double double_v;
+					pipeline.element_get_property_double (element, property, out double_v, out success);
+					if (!success)
+					{
+						stdout.printf("Failed to get property value");
+						ret = false;
+						break;
+					}
+					stdout.printf ("The '%s' value on element '%s' is: %f\n",
+					               property, element, double_v);
+					break;
+
 				case "string":
 					string string_v;
 					pipeline.element_get_property_string (element, property, out string_v, out success);
@@ -455,6 +476,13 @@ public class GstdCli : GLib.Object
 					stdout.printf ("Trying to set '%s' on element '%s' to the value:%lld\n",
 					               property, element, int64_v);
 					ret = pipeline.element_set_property_int64 (element, property, int64_v);
+					break;
+
+				case "double":
+					double double_v = double.parse(args[4]);
+					stdout.printf ("Trying to set '%s' on element '%s' to the value:%f\n",
+					               property, element, double_v);
+					ret = pipeline.element_set_property_double (element, property, double_v);
 					break;
 
 				case "string":
@@ -638,7 +666,7 @@ public class GstdCli : GLib.Object
 
 		try
 		{
-			bool ret = pipeline.pipeline_speed (rate);
+			bool ret = pipeline.pipeline_set_speed (rate);
 			if (!ret)
 			{
 				stderr.printf ("Error:\nSpeed could not be set\n");
@@ -785,7 +813,7 @@ public class GstdCli : GLib.Object
 
 		try
 		{
-			pipeline.element_async_set_state (element, state);
+			pipeline.element_set_state_async (element, state);
 			return true;
 		}
 		catch (Error e)
@@ -1176,13 +1204,13 @@ public class GstdCli : GLib.Object
 				if (args.length > 1)
 				{
 					/* Help about some command */
-					while (cmds[id, 0] != null)
+					while (Cmds(id, 0) != null)
 					{
-						if (cmds[id, 0] == args[1])
+						if (Cmds(id, 0) == args[1])
 						{
 							stdout.printf ("Command: %s\n", args[1]);
-							stdout.printf ("Description:\t%s\n", cmds[id, 2]);
-							stdout.printf ("Syntax: %s\n", cmds[id, 1]);
+							stdout.printf ("Description:\t%s\n", Cmds(id, 2));
+							stdout.printf ("Syntax: %s\n", Cmds(id, 1));
 							return true;
 						}
 						id++;
@@ -1196,10 +1224,10 @@ public class GstdCli : GLib.Object
 					stdout.printf ("Request the syntax of an specific command with " +
 					               "\"help <command>\".\n" +
 					               "This is the list of supported commands:\n");
-					while (cmds[id, 0] != null)
+					while (Cmds(id, 0) != null)
 					{
-						stdout.printf (" %s:%s%s\n", cmds[id, 0],
-						               cmds[id, 0].length < 6 ? "\t\t" : "\t", cmds[id, 2]);
+						stdout.printf (" %s:%s%s\n", Cmds(id, 0),
+						               Cmds(id, 0).length < 6 ? "\t\t" : "\t", Cmds(id, 2));
 						id++;
 					}
 					stdout.printf ("\n");
@@ -1218,7 +1246,7 @@ public class GstdCli : GLib.Object
 	/*
 	   *Interactive Console management
 	 */
-	public bool cli () throws DBus.Error, GLib.Error
+	public bool cli () throws GLib.Error
 	{
 		string[] args;
 

--- a/src/gstd-interfaces.vala
+++ b/src/gstd-interfaces.vala
@@ -75,6 +75,12 @@ namespace gstd {
 		[DBus (name = "ElementSetPropertyInt64Async", no_reply = true)]
 		public abstract void element_set_property_int64_async(string element, string property, int64 val) throws DBusError, IOError;
 
+		[DBus (name = "ElementSetPropertyDouble")]
+		public abstract bool element_set_property_double(string element, string property, double val) throws DBusError, IOError;
+
+		[DBus (name = "ElementSetPropertyDoubleAsync", no_reply = true)]
+		public abstract void element_set_property_double_async(string element, string property, double val) throws DBusError, IOError;
+
 		[DBus (name = "ElementSetPropertyFraction")]
 		public abstract bool element_set_property_fraction(string element, string property, int numerator, int denominator) throws DBusError, IOError;
 
@@ -95,6 +101,9 @@ namespace gstd {
 
 		[DBus (name = "ElementGetPropertyInt64")]
 		public abstract void element_get_property_int64(string element, string property, out int64 val, out bool success) throws DBusError, IOError;
+
+		[DBus (name = "ElementGetPropertyDouble")]
+		public abstract void element_get_property_double(string element, string property, out double val, out bool success) throws DBusError, IOError;
 
 		[DBus (name = "ElementGetPropertyFraction")]
 		public abstract void element_get_property_fraction(string element, string property, out int numerator, out int denominator, out bool success) throws DBusError, IOError;

--- a/src/gstd-pipeline.vala
+++ b/src/gstd-pipeline.vala
@@ -364,6 +364,43 @@ public class Pipeline : GLib.Object, PipelineInterface
 	}
 
 	/**
+	   Sets a double float property for an element on the pipeline
+	   @param element, whose property needs to be set
+	   @param property,property name
+	   @param val, double float property value     */
+	public bool element_set_property_double (string element, string property, double val)
+	{
+		var pipe = _pipeline as Gst.Pipeline;
+		var e = pipe.get_child_by_name (element) as Gst.Element;
+		if (e == null)
+		{
+			Posix.syslog (Posix.LOG_WARNING, "Element %s not found on pipeline", element);
+			return false;
+		}
+
+		var spec = e.get_class ().find_property (property);
+		if (spec == null)
+		{
+			Posix.syslog (Posix.LOG_WARNING, "Element %s does not have the property %s",
+			              element, property);
+			return false;
+		}
+
+		e.set (property, val, null);
+		return true;
+	}
+
+	public void element_set_property_double_async (string element, string property, double val)
+	{
+		try
+		{
+			element_set_property_double(element, property, val);
+		}
+		catch (Error err)
+		{}
+	}
+
+	/**
 	   Sets an fraction property for an element on the pipeline
 	   @param element, whose property needs to be set
 	   @param property, property name
@@ -544,6 +581,43 @@ public class Pipeline : GLib.Object, PipelineInterface
 		}
 
 		e.get (property, &val, null);
+		return true;
+	}
+
+	public void element_get_property_double(string element, string property, out double val, out bool success)
+	{
+		success = element_get_property_double_impl(element, property, out val);
+	}
+
+	/**
+	   Gets an element's double float property value of a specific pipeline
+	   @param element, whose property value wants to be known
+	   @param property,property name
+	   @param val value of the property
+	 */
+	private bool element_get_property_double_impl (string element, string property, out double val)
+	{
+		val = 0;
+
+		var pipe = _pipeline as Gst.Pipeline;
+		var e = pipe.get_child_by_name (element) as Gst.Element;
+		if (e == null)
+		{
+			Posix.syslog (Posix.LOG_WARNING, "Element %s not found on pipeline", element);
+			return false;
+		}
+
+		var spec = e.get_class ().find_property (property);
+		if (spec == null)
+		{
+			Posix.syslog (Posix.LOG_WARNING, "Element %s does not have the property %s",
+			              element, property);
+			return false;
+		}
+
+		Gst.Value tmp = GLib.Value(typeof(double));
+		e.get_property (property, ref tmp);
+		val = tmp.get_double();
 		return true;
 	}
 


### PR DESCRIPTION
# Changes Done
- Able to compile gst-client.vala
- Added support to get and set of an element's property double float values
- Added gio libs to gst-client in src/Makefile.am
## Notes (i was testing under Ubuntu 12.04)

1 - In order to pick up the new src/Makefile.am I had to type in the following commands:

``` bash
aclocal
autoconf
automake
```

 Before the usual:

``` bash
./configure
make
make install
```

2 - In order to run gstd from the command line I had to set the DBUS_STARTER_BUS_TYPE environment variable.
i.e. either by:

``` bash
export DBUS_STARTER_BUS_TYPE=system
nohup gstd &
```

 or

``` bash
DBUS_STARTER_BUS_TYPE=system nohup gstd &
```
